### PR TITLE
setting_for_rails_g

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,13 @@ module Myapp
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
 
+    config.generators.system_tests = nil
+    config.generators do |g|
+      g.skip_routes true
+      g.helper false
+      g.test_framework nil
+    end
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files


### PR DESCRIPTION
### 概要
アプリの基本設定(rails g)

### 内容
config/application.rbファイルにて以下の内容を設定
* g.skip_routes true
  * ルーティングの記述を加えないように設定
* g.helper false
  * ヘルパーファイルを自動生成しないように設定
* g.test_framework nil
  * テストフレームワークを使わないように設定